### PR TITLE
added custom iam role name

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,22 @@ module "tinfoil_sa" {
 }
 ```
 
+### Create an IAM role component and Kubernetes service account and specify the IAM role name
+
+```
+module "tinfoil_sa" {
+    source                      = "tinfoilcipher/eks-service-account-with-oidc-iam-role/aws"
+    version                     = "x.x.x"
+    service_account_name        = "my-service-account"
+    iam_policy_arns             = ["arn:aws:iam::aws:policy/AmazonS3FullAccess", "arn:aws:iam::123456789012:policy/custom-policy"]
+    kubernetes_namespace        = "some-namespace"
+    enabled_sts_services        = ["ec2", "rds", "s3"]
+    openid_connect_provider_arn = module.eks_cluster.oidc_provider_arn
+    openid_connect_provider_url = module.eks_cluster.oidc_provider_url
+    iam_role_name               = "my-iam-role-name"
+}
+```
+
 ### Create IAM Role Componenets Only
 
 ```

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "this" {
-    name                = "${var.service_account_name}-role"
+    name                = var.iam_role_name != "" ? var.iam_role_name : "${var.service_account_name}-role"
     assume_role_policy  = data.aws_iam_policy_document.this.json
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,12 @@ variable "service_account_name" {
     type        = string
 }
 
+variable "iam_role_name" {
+    description = "AWS IAM Role name (If not specified, ${service_account_name}-role is defaulted.)"
+    type        = string
+    default     = ""
+}
+
 variable "iam_policy_arns" {
     description = "List of IAM Policy ARNs to Attach to IAM Role"
     type        = list(string)


### PR DESCRIPTION
Added iam role name that can be specified. If not specified, the iam role name will be created according to the original rules.